### PR TITLE
Add analytics dashboard and product shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# React + Vite
+# Mushroom Ecommerce Demo
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project is a simple ecommerce prototype built with **React** and **Vite**. It showcases a small catalog of mushroom spore products and features an admin dashboard for tracking analytics.
 
-Currently, two official plugins are available:
+## Key Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+* Product catalog with images, descriptions and prices
+* Lightweight analytics stored in `localStorage`
+* Admin dashboard displaying page and product views using Chart.js
+* Dark and light theme toggle
 
-## Expanding the ESLint configuration
+To run the project locally:
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+npm install
+npm run dev
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-shroom-store",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.4.9",
         "framer-motion": "^12.15.0",
         "prop-types": "^15.8.1",
         "react": "^19.1.0",
@@ -1032,6 +1033,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
@@ -1752,6 +1759,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/cli-boxes": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.4.9",
     "framer-motion": "^12.15.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",

--- a/src/AnalyticsContext.jsx
+++ b/src/AnalyticsContext.jsx
@@ -1,0 +1,57 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+const AnalyticsContext = createContext();
+
+const defaultAnalytics = {
+  pages: {
+    Home: 0,
+    Shop: 0,
+    Mycology101: 0,
+    About: 0,
+    Admin: 0,
+  },
+  products: {},
+};
+
+export function AnalyticsProvider({ children }) {
+  const [analytics, setAnalytics] = useState(() => {
+    try {
+      const stored = localStorage.getItem('analytics');
+      return stored ? JSON.parse(stored) : defaultAnalytics;
+    } catch {
+      return defaultAnalytics;
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem('analytics', JSON.stringify(analytics));
+  }, [analytics]);
+
+  const recordPageView = (page) => {
+    setAnalytics((prev) => ({
+      ...prev,
+      pages: {
+        ...prev.pages,
+        [page]: (prev.pages[page] || 0) + 1,
+      },
+    }));
+  };
+
+  const recordProductView = (product) => {
+    setAnalytics((prev) => ({
+      ...prev,
+      products: {
+        ...prev.products,
+        [product]: (prev.products[product] || 0) + 1,
+      },
+    }));
+  };
+
+  return (
+    <AnalyticsContext.Provider value={{ analytics, recordPageView, recordProductView }}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+}
+
+export default AnalyticsContext;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,7 @@ import Home from "./views/Home";
 import Shop from "./views/Shop";
 import Mycology101 from "./views/Mycology101";
 import About from "./views/About";
+import AdminDashboard from "./views/AdminDashboard";
 
 export default function App() {
   // -------------------------------
@@ -91,6 +92,7 @@ export default function App() {
           <Route path="/shop" element={<Shop lightMode={lightMode} />} />
           <Route path="/mycology" element={<Mycology101 lightMode={lightMode} />} />
           <Route path="/about" element={<About lightMode={lightMode} />} />
+          <Route path="/admin" element={<AdminDashboard />} />
         </Routes>
       </div>
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -35,15 +35,10 @@
 // ================================
 import React from "react";
 import { Link } from "react-router-dom";
-import { FaHome, FaStore, FaInfoCircle, FaLeaf, FaMoon, FaSun } from "react-icons/fa";
-import { motion } from "framer-motion";
+import { FaHome, FaStore, FaInfoCircle, FaLeaf } from "react-icons/fa";
 import "./Footer.css";
 
-export default function Footer({ lightMode, onToggleTheme }) {
-  // Accessible dark mode icon toggle
-  const themeIcon = lightMode
-    ? <FaMoon aria-label="Switch to dark mode" />
-    : <FaSun aria-label="Switch to light mode" />;
+export default function Footer() {
 
   return (
     <footer className="footer-glass" id="footer" role="contentinfo">

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -29,7 +29,7 @@
 // ================================
 
 // SideBar.jsx
-import { FaHome, FaInfoCircle, FaStore, FaLeaf } from "react-icons/fa";
+import { FaHome, FaInfoCircle, FaStore, FaLeaf, FaChartBar } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { useState } from "react";
 import "./SideBar.css";
@@ -68,6 +68,11 @@ export default function SideBar() {
           <li>
             <Link className="trippy-link" to="/about">
               <FaInfoCircle className="sidebar-icon" /> About
+            </Link>
+          </li>
+          <li>
+            <Link className="trippy-link" to="/admin">
+              <FaChartBar className="sidebar-icon" /> Admin
             </Link>
           </li>
         </ul>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from "react-router-dom";
 import './index.css'
 import App from './App.jsx'
+import { AnalyticsProvider } from './AnalyticsContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AnalyticsProvider>
+        <App />
+      </AnalyticsProvider>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/src/views/About.jsx
+++ b/src/views/About.jsx
@@ -28,10 +28,17 @@
 //   • Semantic HTML for better SEO
 // ================================
 
-import React from "react";
+import React, { useEffect, useContext } from "react";
+import AnalyticsContext from "../AnalyticsContext.jsx";
 import "./About.css";
 
 export default function About() {
+  const { recordPageView } = useContext(AnalyticsContext);
+
+  useEffect(() => {
+    recordPageView('About');
+  }, [recordPageView]);
+
   return (
     <>
       <main className="main-content">

--- a/src/views/AdminDashboard.css
+++ b/src/views/AdminDashboard.css
@@ -1,0 +1,27 @@
+.admin-dashboard {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+  font-family: 'Audiowide', 'Segoe UI', Arial, sans-serif;
+}
+
+.admin-dashboard header h1 {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(180deg, #ffe97a 20%, #7b61ff 70%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.charts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.chart-container {
+  width: 400px;
+  max-width: 90%;
+}

--- a/src/views/AdminDashboard.jsx
+++ b/src/views/AdminDashboard.jsx
@@ -1,0 +1,68 @@
+import React, { useContext, useEffect, useRef } from 'react';
+import AnalyticsContext from '../AnalyticsContext.jsx';
+import './AdminDashboard.css';
+import { Chart } from 'chart.js/auto';
+
+export default function AdminDashboard() {
+  const { analytics, recordPageView } = useContext(AnalyticsContext);
+  const pageChartRef = useRef(null);
+  const productChartRef = useRef(null);
+
+  useEffect(() => {
+    recordPageView('Admin');
+    const pageCtx = pageChartRef.current.getContext('2d');
+    const productCtx = productChartRef.current.getContext('2d');
+
+    const pageChart = new Chart(pageCtx, {
+      type: 'bar',
+      data: {
+        labels: Object.keys(analytics.pages),
+        datasets: [{
+          label: 'Page Views',
+          data: Object.values(analytics.pages),
+          backgroundColor: 'rgba(123,97,255,0.6)',
+        }],
+      },
+      options: {
+        responsive: true,
+      },
+    });
+
+    const productChart = new Chart(productCtx, {
+      type: 'bar',
+      data: {
+        labels: Object.keys(analytics.products),
+        datasets: [{
+          label: 'Product Views',
+          data: Object.values(analytics.products),
+          backgroundColor: 'rgba(255,105,97,0.6)',
+        }],
+      },
+      options: {
+        responsive: true,
+      },
+    });
+
+    return () => {
+      pageChart.destroy();
+      productChart.destroy();
+    };
+  }, [analytics, recordPageView]);
+
+  return (
+    <main className="admin-dashboard">
+      <header>
+        <h1>Admin Dashboard</h1>
+        <p>Analytics Overview</p>
+      </header>
+      <section className="charts">
+        <div className="chart-container">
+          <canvas ref={pageChartRef} aria-label="Page view chart" />
+        </div>
+        <div className="chart-container">
+          <canvas ref={productChartRef} aria-label="Product view chart" />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -30,9 +30,17 @@
 // ================================
 
 
+import { useEffect, useContext } from "react";
 import WelcomeBanner from "../components/WelcomeBanner";
+import AnalyticsContext from "../AnalyticsContext.jsx";
 
 export default function Home({ lightMode, appSectionClass }) {
+    const { recordPageView } = useContext(AnalyticsContext);
+
+    useEffect(() => {
+        recordPageView('Home');
+    }, [recordPageView]);
+
     return (
         <>
             <main className="main-content">

--- a/src/views/Mycology101.jsx
+++ b/src/views/Mycology101.jsx
@@ -10,12 +10,20 @@
 //   • Accessibility considerations for educational material
 // ================================
 
+import { useEffect, useContext } from "react";
 import SideBar from "../components/SideBar";
 import "./Mycology101.css";
+import AnalyticsContext from "../AnalyticsContext.jsx";
 
 
 
 export default function Mycology101() {
+    const { recordPageView } = useContext(AnalyticsContext);
+
+    useEffect(() => {
+        recordPageView('Mycology101');
+    }, [recordPageView]);
+
     return (
         <>
             <main className="main-content">

--- a/src/views/Shop.css
+++ b/src/views/Shop.css
@@ -30,19 +30,21 @@
   text-shadow:  0px 8px 15px  lch(100% 0.01 296.81 / 0.483);
 }
 
-.shop-content {
+.product-grid {
   background: lch(96% 12 245 / 0.23);
   border-radius: 1.2rem;
   box-shadow: 0 4px 20px lch(60% 42 265 / 0.11);
   margin: 2.5rem auto;
-  padding: 2.7rem 2rem 2rem 2rem;
+  padding: 2rem;
   max-width: 880px;
-  text-align: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
   animation: fadeInUp 1.4s cubic-bezier(.77,0,.18,1) 1.3s both;
   font-family: 'Audiowide', 'Segoe UI', Arial, sans-serif;
 }
 
-.shop-content h2 {
+.product-card h2 {
   font-size: 2.9rem;
   color: lch(36% 58 265);
   margin-bottom: 1.4rem;
@@ -54,42 +56,48 @@
   text-shadow: 0 2px 12px lch(0% 0 0 / 0.146);
 }
 
-.shop-content p {
+.product-card .description {
   font-family: 'Courier New', Courier, monospace;
   color: lch(6.92% 13.64 262.64);
   font-size: 1.5rem;
-  margin-bottom: 4rem;
+  margin-bottom: 1rem;
   font-weight: 550;
   line-height: 1.6;
 }
 
-.shop-content ul {
-  list-style: square inside;
-  color: lch(7.34% 13.77 261.36);
-  margin: 0 auto 1.4rem auto;
-  padding: 0;
-  font-size: 1.5rem;
-  max-width: 400px;
+.product-card .price {
+  font-size: 1.4rem;
+  color: lch(40% 40 265);
+  font-weight: bold;
 }
 
-.shop-content li {
-  margin-bottom: 1.5rem;
-}
-
-.coming-soon {
-  border-left: 5px solid #7b61ff;
-  padding-left: 1.5rem;
-  background: lch(62.51% 38.46 246.4 / 0.247);
+.product-card img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
   border-radius: 0.6rem;
-  box-shadow: 0 1px 7px lch(35% 14 250 / 0.09);
+  margin-bottom: 0.5rem;
+  box-shadow: 0 4px 12px lch(35% 14 250 / 0.2);
 }
+
+.product-card {
+  text-align: center;
+  padding: 1rem;
+  background: lch(98% 10 245 / 0.3);
+  border-radius: 0.8rem;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.product-card:hover {
+  transform: translateY(-4px);
+}
+
+
 
 @media (max-width: 800px) {
-  .shop-content {
-    padding: 1.3rem 0.5rem;
-  }
-  .coming-soon {
-    padding-left: 0.7rem;
+  .product-grid {
+    padding: 1rem;
   }
 }
 

--- a/src/views/Shop.jsx
+++ b/src/views/Shop.jsx
@@ -1,40 +1,61 @@
-// ================================
-// Shop.jsx
-// ================================
-// The shop page component that displays mushroom products for sale.
-// This component will eventually show spores, grow kits, and other supplies.
-//
-// Key Concepts Covered:
-//   • Component composition
-//   • Semantic HTML structure
-//   • Future e-commerce layout preparation
-// ================================
+import React, { useContext, useEffect } from 'react';
+import AnalyticsContext from '../AnalyticsContext.jsx';
+import './Shop.css';
 
-import SideBar from "../components/SideBar";
-import "./Shop.css";
-// Shop.jsx - The shop page component that displays mushroom products for sale. 
-
+const products = [
+  {
+    name: 'Mazatapec',
+    image: '/assets/MAZATAPEC.jpg',
+    description: 'Classic Psilocybe cubensis strain from Mexico.',
+    price: '$20',
+  },
+  {
+    name: 'Blue Mini',
+    image: '/assets/BLUE MINI.jpg',
+    description: 'Compact variety with vivid blue hues.',
+    price: '$18',
+  },
+  {
+    name: 'PF Classic',
+    image: '/assets/PF CLASSIC.jpg',
+    description: 'Beginner-friendly spores for PF Tek enthusiasts.',
+    price: '$15',
+  },
+  {
+    name: 'Z-Strain',
+    image: '/assets/z strain.jpg',
+    description: 'Popular strain known for consistent growth.',
+    price: '$22',
+  },
+];
 
 export default function Shop() {
-    return (
-        <>
-            <main className="main-content">
-                <header id="main-header">
-                    <h1>Mushroom Shop</h1>
-                    <p>Premium spores and growing supplies</p>
-                </header>
-                <section className="shop-content">
-                    <div className="coming-soon">
-                        <h2>🍄 Coming Soon!</h2>
-                        <p>Our mushroom spore collection and growing kits will be available here soon.</p>
-                        <ul>
-                            <li>Premium spore syringes</li>
-                            <li>Mushroom growing kits</li>
-                            <li>Cultivation supplies</li>
-                            <li>Educational materials</li>
-                        </ul>
-                    </div>                </section>
-            </main>
-        </>
-    );
+  const { recordPageView, recordProductView } = useContext(AnalyticsContext);
+
+  useEffect(() => {
+    recordPageView('Shop');
+  }, [recordPageView]);
+
+  return (
+    <main className="main-content">
+      <header id="main-header">
+        <h1>Mushroom Shop</h1>
+        <p>Premium spores and growing supplies</p>
+      </header>
+      <section className="product-grid">
+        {products.map((p) => (
+          <div
+            key={p.name}
+            className="product-card"
+            onClick={() => recordProductView(p.name)}
+          >
+            <img src={p.image} alt={p.name} />
+            <h2>{p.name}</h2>
+            <p className="description">{p.description}</p>
+            <p className="price">{p.price}</p>
+          </div>
+        ))}
+      </section>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- add `AnalyticsContext` for page/product tracking
- integrate analytics provider in `main.jsx`
- create `AdminDashboard` with Chart.js graphs
- build out Shop view with product cards
- update navigation sidebar and footer
- update README with usage information

## Testing
- `npm run build`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_6843593bcb5883299559c403633291b6