### PR TITLE
Add admin dashboard view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,7 @@ import Home from "./views/Home";
 import Shop from "./views/Shop";
 import Mycology101 from "./views/Mycology101";
 import About from "./views/About";
+import AdminDashboard from "./views/AdminDashboard";
 
 export default function App() {
   // -------------------------------
@@ -91,6 +92,7 @@ export default function App() {
           <Route path="/shop" element={<Shop lightMode={lightMode} />} />
           <Route path="/mycology" element={<Mycology101 lightMode={lightMode} />} />
           <Route path="/about" element={<About lightMode={lightMode} />} />
+          <Route path="/admin" element={<AdminDashboard />} />
         </Routes>
       </div>
 

--- a/src/views/AdminDashboard.css
+++ b/src/views/AdminDashboard.css
@@ -1,0 +1,17 @@
+.dashboard-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.admin-section {
+  margin-bottom: 2rem;
+  padding: 1rem;
+  background: var(--color-background, #f0f0f0);
+  border-radius: 8px;
+}
+
+.customer-form label {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}

--- a/src/views/AdminDashboard.jsx
+++ b/src/views/AdminDashboard.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import "./AdminDashboard.css";
+
+function CustomerInfo() {
+  return (
+    <section className="admin-section" id="customer-info">
+      <h2>Customer Info</h2>
+      <form className="customer-form">
+        <label>
+          Email:
+          <input type="email" name="email" />
+        </label>
+        <button type="submit">Add</button>
+      </form>
+    </section>
+  );
+}
+
+function SalesData() {
+  return (
+    <section className="admin-section" id="sales-data">
+      <h2>Sales Data</h2>
+      <p>Coming soon: graphs and metrics.</p>
+    </section>
+  );
+}
+
+function InventoryStatus() {
+  return (
+    <section className="admin-section" id="inventory-status">
+      <h2>Inventory Status</h2>
+      <p>Current inventory overview will appear here.</p>
+    </section>
+  );
+}
+
+export default function AdminDashboard() {
+  return (
+    <main className="main-content admin-dashboard">
+      <header className="dashboard-header">
+        <h1>Admin Dashboard</h1>
+        <p>Manage store insights and data</p>
+      </header>
+      <CustomerInfo />
+      <SalesData />
+      <InventoryStatus />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple AdminDashboard view with child components
- style admin dashboard
- register `/admin` route

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435723fd0083298c5732d71514c260