### PR TITLE
Stabilize analytics callbacks and dashboard chart effects

### DIFF
--- a/src/AnalyticsContext.jsx
+++ b/src/AnalyticsContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect } from 'react';
+import React, { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 
 const AnalyticsContext = createContext();
 
@@ -55,7 +55,7 @@ export function AnalyticsProvider({ children }) {
     localStorage.setItem('analytics', JSON.stringify(analytics));
   }, [analytics]);
 
-  const recordPageView = (page) => {
+  const recordPageView = useCallback((page) => {
     const timestamp = Date.now();
     setAnalytics((prev) => ({
       ...prev,
@@ -65,9 +65,9 @@ export function AnalyticsProvider({ children }) {
       },
       events: [...prev.events, { type: 'page', name: page, timestamp }],
     }));
-  };
+  }, []);
 
-  const recordProductView = (product) => {
+  const recordProductView = useCallback((product) => {
     const timestamp = Date.now();
     setAnalytics((prev) => ({
       ...prev,
@@ -77,31 +77,34 @@ export function AnalyticsProvider({ children }) {
       },
       events: [...prev.events, { type: 'product', name: product, timestamp }],
     }));
-  };
+  }, []);
 
-  const getDailySummary = () => {
+  const getDailySummary = useCallback((events = []) => {
     const summary = {};
-    analytics.events.forEach((evt) => {
+    events.forEach((evt) => {
       const day = new Date(evt.timestamp).toLocaleDateString();
       summary[day] = (summary[day] || 0) + 1;
     });
     return summary;
-  };
+  }, []);
 
-  const resetAnalytics = () => {
+  const resetAnalytics = useCallback(() => {
     setAnalytics(defaultAnalytics);
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      analytics,
+      recordPageView,
+      recordProductView,
+      resetAnalytics,
+      getDailySummary,
+    }),
+    [analytics, recordPageView, recordProductView, resetAnalytics, getDailySummary],
+  );
 
   return (
-    <AnalyticsContext.Provider
-      value={{
-        analytics,
-        recordPageView,
-        recordProductView,
-        resetAnalytics,
-        getDailySummary,
-      }}
-    >
+    <AnalyticsContext.Provider value={value}>
       {children}
     </AnalyticsContext.Provider>
   );

--- a/src/views/AdminDashboard.jsx
+++ b/src/views/AdminDashboard.jsx
@@ -32,7 +32,9 @@ export default function AdminDashboard() {
 
   useEffect(() => {
     recordPageView('Admin');
+  }, [recordPageView]);
 
+  useEffect(() => {
     if (!pageChartRef.current || !productChartRef.current) {
       return undefined;
     }
@@ -40,7 +42,7 @@ export default function AdminDashboard() {
     const pageCtx = pageChartRef.current.getContext('2d');
     const productCtx = productChartRef.current.getContext('2d');
 
-    const dailySummary = getDailySummary();
+    const dailySummary = getDailySummary(analytics.events);
 
     const pageChart = new Chart(pageCtx, {
       type: 'line',
@@ -82,7 +84,7 @@ export default function AdminDashboard() {
       pageChart.destroy();
       productChart.destroy();
     };
-  }, [analytics, recordPageView, getDailySummary]);
+  }, [analytics.events, analytics.products, getDailySummary]);
 
   return (
     <main className="admin-dashboard">


### PR DESCRIPTION
### Motivation
- Prevent consumers from receiving new function/object identities on every provider render to avoid unnecessary re-renders and duplicate analytics recordings. 
- Make the daily summary calculation a pure, stable helper so chart code can depend on a stable API rather than the entire analytics object. 
- Separate page-view recording from chart lifecycle so recording runs once on mount while charts re-render only when their data changes.

### Description
- In `src/AnalyticsContext.jsx` imported `useCallback` and `useMemo` and wrapped `recordPageView`, `recordProductView`, and `resetAnalytics` in `useCallback` to stabilize their identities. 
- Refactored `getDailySummary` into a `useCallback` that accepts an `events` array argument and returns a per-day summary, removing its dependency on the full `analytics` object. 
- Memoized the provider `value` with `useMemo` so the context value object is stable unless its dependencies change. 
- In `src/views/AdminDashboard.jsx` split the single effect into two: one effect that calls `recordPageView('Admin')` once on mount, and a separate effect that creates/destroys charts and depends specifically on `analytics.events`, `analytics.products`, and the stable `getDailySummary` helper; the charts now call `getDailySummary(analytics.events)`.
- Left route pages (`Home.jsx`, `Shop.jsx`, `About.jsx`, `Mycology101.jsx`) using mount-only effects that call `recordPageView`, which with the stable context callbacks will no longer record repeatedly due to provider rerenders.

### Testing
- Ran `npm ci` which completed successfully. 
- Built the production bundle with `npm run build` which completed successfully. 
- Ran linting with `npx eslint` on the modified and related files which returned without errors. 
- Confirmed no diff-check issues with `git diff --check` (no whitespace or obvious diff errors found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bbd378a888329963e295a79810b2b)