### PR TITLE
Add persistent cart flow with CartContext, cart page, UI, and analytics events

### DIFF
--- a/src/AnalyticsContext.jsx
+++ b/src/AnalyticsContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect } from 'react';
+import React, { createContext, useCallback, useMemo, useState, useEffect } from 'react';
 
 const AnalyticsContext = createContext();
 
@@ -55,8 +55,18 @@ export function AnalyticsProvider({ children }) {
     localStorage.setItem('analytics', JSON.stringify(analytics));
   }, [analytics]);
 
-  const recordPageView = (page) => {
+  const recordEvent = useCallback((type, name, metadata = {}) => {
     const timestamp = Date.now();
+
+    setAnalytics((prev) => ({
+      ...prev,
+      events: [...prev.events, { type, name, timestamp, metadata }],
+    }));
+  }, []);
+
+  const recordPageView = useCallback((page) => {
+    const timestamp = Date.now();
+
     setAnalytics((prev) => ({
       ...prev,
       pages: {
@@ -65,10 +75,11 @@ export function AnalyticsProvider({ children }) {
       },
       events: [...prev.events, { type: 'page', name: page, timestamp }],
     }));
-  };
+  }, []);
 
-  const recordProductView = (product) => {
+  const recordProductView = useCallback((product) => {
     const timestamp = Date.now();
+
     setAnalytics((prev) => ({
       ...prev,
       products: {
@@ -77,34 +88,34 @@ export function AnalyticsProvider({ children }) {
       },
       events: [...prev.events, { type: 'product', name: product, timestamp }],
     }));
-  };
+  }, []);
 
-  const getDailySummary = () => {
+  const getDailySummary = useCallback(() => {
     const summary = {};
     analytics.events.forEach((evt) => {
       const day = new Date(evt.timestamp).toLocaleDateString();
       summary[day] = (summary[day] || 0) + 1;
     });
     return summary;
-  };
+  }, [analytics.events]);
 
-  const resetAnalytics = () => {
+  const resetAnalytics = useCallback(() => {
     setAnalytics(defaultAnalytics);
-  };
+  }, []);
 
-  return (
-    <AnalyticsContext.Provider
-      value={{
-        analytics,
-        recordPageView,
-        recordProductView,
-        resetAnalytics,
-        getDailySummary,
-      }}
-    >
-      {children}
-    </AnalyticsContext.Provider>
+  const value = useMemo(
+    () => ({
+      analytics,
+      recordEvent,
+      recordPageView,
+      recordProductView,
+      resetAnalytics,
+      getDailySummary,
+    }),
+    [analytics, getDailySummary, recordEvent, recordPageView, recordProductView, resetAnalytics],
   );
+
+  return <AnalyticsContext.Provider value={value}>{children}</AnalyticsContext.Provider>;
 }
 
 export default AnalyticsContext;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Footer from './components/Footer';
 import SideBar from './components/SideBar';
 import Home from './views/Home';
 import Shop from './views/Shop';
+import Cart from './views/Cart';
 import Mycology101 from './views/Mycology101';
 import About from './views/About';
 import AdminDashboard from './views/AdminDashboard';
@@ -64,6 +65,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Home lightMode={lightMode} appSectionClass={appSectionClass} />} />
           <Route path="/shop" element={<Shop lightMode={lightMode} />} />
+          <Route path="/cart" element={<Cart />} />
           <Route path="/mycology" element={<Mycology101 lightMode={lightMode} />} />
           <Route path="/about" element={<About lightMode={lightMode} />} />
           <Route path="/admin" element={<AdminDashboard />} />

--- a/src/CartContext.jsx
+++ b/src/CartContext.jsx
@@ -1,0 +1,167 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import AnalyticsContext from './AnalyticsContext.jsx';
+
+const CART_STORAGE_KEY = 'cart:v1';
+
+const CartContext = createContext(null);
+
+function parsePrice(price) {
+  if (typeof price === 'number') {
+    return Number.isFinite(price) ? price : 0;
+  }
+
+  const parsed = Number.parseFloat(String(price ?? '').replace(/[^0-9.-]+/g, ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getProductId(product) {
+  return product?.id ?? product?.name;
+}
+
+function normalizeProduct(product) {
+  const id = getProductId(product);
+
+  if (!id) {
+    throw new Error('Cannot add a product to the cart without an id or name.');
+  }
+
+  return {
+    id: String(id),
+    name: product.name ?? 'Untitled product',
+    image: product.image ?? '',
+    price: parsePrice(product.price),
+  };
+}
+
+function normalizeQuantity(quantity) {
+  const nextQuantity = Number(quantity);
+  return Number.isFinite(nextQuantity) ? Math.max(0, Math.floor(nextQuantity)) : 0;
+}
+
+function readStoredCart() {
+  try {
+    const storedCart = localStorage.getItem(CART_STORAGE_KEY);
+    if (!storedCart) {
+      return [];
+    }
+
+    const parsedCart = JSON.parse(storedCart);
+    return Array.isArray(parsedCart)
+      ? parsedCart
+          .map((item) => ({
+            ...normalizeProduct(item),
+            quantity: Math.max(1, normalizeQuantity(item.quantity)),
+          }))
+          .filter((item) => item.quantity > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function CartProvider({ children }) {
+  const { recordEvent } = useContext(AnalyticsContext);
+  const [items, setItems] = useState(readStoredCart);
+
+  useEffect(() => {
+    localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
+  }, [items]);
+
+  const addItem = useCallback(
+    (product) => {
+      const productToAdd = normalizeProduct(product);
+
+      setItems((currentItems) => {
+        const existingItem = currentItems.find((item) => item.id === productToAdd.id);
+
+        if (existingItem) {
+          return currentItems.map((item) =>
+            item.id === productToAdd.id ? { ...item, quantity: item.quantity + 1 } : item,
+          );
+        }
+
+        return [...currentItems, { ...productToAdd, quantity: 1 }];
+      });
+
+      recordEvent('cart_add', productToAdd.name, {
+        productId: productToAdd.id,
+        price: productToAdd.price,
+      });
+    },
+    [recordEvent],
+  );
+
+  const removeItem = useCallback(
+    (productId) => {
+      const safeProductId = String(productId);
+      const removedItem = items.find((item) => item.id === safeProductId);
+
+      setItems((currentItems) => currentItems.filter((item) => item.id !== safeProductId));
+
+      recordEvent('cart_remove', removedItem?.name ?? safeProductId, {
+        productId: safeProductId,
+      });
+    },
+    [items, recordEvent],
+  );
+
+  const updateQuantity = useCallback(
+    (productId, quantity) => {
+      const safeProductId = String(productId);
+      const safeQuantity = normalizeQuantity(quantity);
+      const changedItem = items.find((item) => item.id === safeProductId);
+
+      setItems((currentItems) => {
+        if (safeQuantity <= 0) {
+          return currentItems.filter((item) => item.id !== safeProductId);
+        }
+
+        return currentItems.map((item) => (item.id === safeProductId ? { ...item, quantity: safeQuantity } : item));
+      });
+
+      recordEvent('quantity_change', changedItem?.name ?? safeProductId, {
+        productId: safeProductId,
+        quantity: safeQuantity,
+      });
+    },
+    [items, recordEvent],
+  );
+
+  const clearCart = useCallback(() => {
+    setItems([]);
+  }, []);
+
+  const totals = useMemo(() => {
+    const itemCount = items.reduce((sum, item) => sum + item.quantity, 0);
+    const subtotal = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+    return { itemCount, subtotal };
+  }, [items]);
+
+  const value = useMemo(
+    () => ({
+      items,
+      itemCount: totals.itemCount,
+      subtotal: totals.subtotal,
+      addItem,
+      removeItem,
+      updateQuantity,
+      clearCart,
+    }),
+    [addItem, clearCart, items, removeItem, totals.itemCount, totals.subtotal, updateQuantity],
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart() {
+  const context = useContext(CartContext);
+
+  if (!context) {
+    throw new Error('useCart must be used within a CartProvider.');
+  }
+
+  return context;
+}
+
+export default CartContext;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -35,7 +35,7 @@
 // ================================
 import React from "react";
 import { Link } from "react-router-dom";
-import { FaHome, FaStore, FaInfoCircle, FaLeaf } from "react-icons/fa";
+import { FaHome, FaStore, FaInfoCircle, FaLeaf, FaShoppingCart } from "react-icons/fa";
 import "./Footer.css";
 
 export default function Footer() {
@@ -46,6 +46,7 @@ export default function Footer() {
           <ul>
             <li><Link to="/" aria-label="Home"><FaHome /> <span>Home</span></Link></li>
             <li><Link to="/shop" aria-label="Shop"><FaStore /> <span>Shop</span></Link></li>
+            <li><Link to="/cart" aria-label="Cart"><FaShoppingCart /> <span>Cart</span></Link></li>
             <li><Link to="/about" aria-label="About"><FaInfoCircle /> <span>About</span></Link></li>
             <li><Link to="/mycology" aria-label="Mycology 101"><FaLeaf /> <span>Mycology</span></Link></li>
           </ul>

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -29,7 +29,7 @@
 // ================================
 
 // SideBar.jsx
-import { FaHome, FaInfoCircle, FaStore, FaLeaf, FaChartBar } from "react-icons/fa";
+import { FaHome, FaInfoCircle, FaStore, FaLeaf, FaChartBar, FaShoppingCart } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { useState } from "react";
 import "./SideBar.css";
@@ -58,6 +58,11 @@ export default function SideBar() {
           <li>
             <Link className="trippy-link" to="/shop">
               <FaStore className="sidebar-icon" /> Shop
+            </Link>
+          </li>
+          <li>
+            <Link className="trippy-link" to="/cart">
+              <FaShoppingCart className="sidebar-icon" /> Cart
             </Link>
           </li>
           <li>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,12 +4,15 @@ import { BrowserRouter } from "react-router-dom";
 import './index.css'
 import App from './App.jsx'
 import { AnalyticsProvider } from './AnalyticsContext.jsx'
+import { CartProvider } from './CartContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
       <AnalyticsProvider>
-        <App />
+        <CartProvider>
+          <App />
+        </CartProvider>
       </AnalyticsProvider>
     </BrowserRouter>
   </StrictMode>,

--- a/src/views/Cart.css
+++ b/src/views/Cart.css
@@ -1,0 +1,150 @@
+.cart-page {
+  width: min(1000px, calc(100% - 2rem));
+  margin: 2.5rem auto 8rem;
+  color: lch(12% 15 265);
+}
+
+.cart-header,
+.cart-empty,
+.cart-panel {
+  background: lch(98% 8 245 / 0.58);
+  border-radius: 1.2rem;
+  box-shadow: 0 4px 20px lch(45% 45 265 / 0.25);
+  backdrop-filter: blur(8px);
+}
+
+.cart-header,
+.cart-empty {
+  padding: 2rem;
+  text-align: center;
+}
+
+.cart-header h1,
+.cart-empty h2 {
+  margin-top: 0;
+  font-family: 'Audiowide', 'Segoe UI', Arial, sans-serif;
+  color: lch(36% 58 265);
+}
+
+.cart-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+}
+
+.cart-items {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cart-item {
+  display: grid;
+  grid-template-columns: 90px minmax(140px, 1fr) 90px 110px auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background: lch(100% 5 245 / 0.55);
+  border-radius: 0.9rem;
+}
+
+.cart-item-image {
+  width: 90px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: 0.6rem;
+}
+
+.cart-item-details h2 {
+  margin: 0 0 0.3rem;
+  font-size: 1.25rem;
+}
+
+.cart-item-details p,
+.cart-line-total {
+  margin: 0;
+  font-weight: 700;
+}
+
+.cart-quantity {
+  display: grid;
+  gap: 0.25rem;
+  font-weight: 700;
+}
+
+.cart-quantity input {
+  width: 5rem;
+  border: 2px solid lch(65% 30 265);
+  border-radius: 0.5rem;
+  padding: 0.45rem;
+  font: inherit;
+}
+
+.cart-summary {
+  align-self: start;
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  background: lch(92% 12 245 / 0.65);
+  border-radius: 0.9rem;
+}
+
+.cart-summary p {
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+}
+
+.add-to-cart-btn,
+.checkout-start-btn,
+.cart-shop-link,
+.cart-remove-btn,
+.cart-clear-btn {
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-family: 'Audiowide', 'Segoe UI', Arial, sans-serif;
+  font-size: 1rem;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.add-to-cart-btn,
+.checkout-start-btn,
+.cart-shop-link {
+  background: linear-gradient(135deg, #7b61ff, #ffe97a);
+  color: lch(10% 10 265);
+  box-shadow: 0 4px 12px lch(45% 60 285 / 0.25);
+}
+
+.cart-remove-btn,
+.cart-clear-btn {
+  background: lch(96% 20 35 / 0.9);
+  color: lch(28% 45 35);
+}
+
+.add-to-cart-btn:hover,
+.checkout-start-btn:hover,
+.cart-shop-link:hover,
+.cart-remove-btn:hover,
+.cart-clear-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px lch(45% 60 285 / 0.28);
+}
+
+@media (max-width: 820px) {
+  .cart-panel,
+  .cart-item {
+    grid-template-columns: 1fr;
+  }
+
+  .cart-item-image {
+    width: 100%;
+    height: 160px;
+  }
+}

--- a/src/views/Cart.jsx
+++ b/src/views/Cart.jsx
@@ -1,0 +1,93 @@
+import React, { useContext, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import AnalyticsContext from '../AnalyticsContext.jsx';
+import { useCart } from '../CartContext.jsx';
+import './Cart.css';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+function formatCurrency(amount) {
+  return currencyFormatter.format(amount);
+}
+
+export default function Cart() {
+  const { recordEvent, recordPageView } = useContext(AnalyticsContext);
+  const { items, itemCount, subtotal, removeItem, updateQuantity, clearCart } = useCart();
+
+  useEffect(() => {
+    recordPageView('Cart');
+  }, [recordPageView]);
+
+  const handleCheckoutStart = () => {
+    recordEvent('checkout_start', 'Cart checkout', {
+      itemCount,
+      subtotal,
+    });
+  };
+
+  return (
+    <main className="cart-page">
+      <header className="cart-header">
+        <h1>Your Cart</h1>
+        <p>Review quantities and start checkout when you are ready.</p>
+      </header>
+
+      {items.length === 0 ? (
+        <section className="cart-empty" aria-live="polite">
+          <h2>Your cart is empty.</h2>
+          <p>Add a product from the shop to begin building your order.</p>
+          <Link className="cart-shop-link" to="/shop">
+            Browse products
+          </Link>
+        </section>
+      ) : (
+        <section className="cart-panel" aria-label="Shopping cart line items">
+          <ul className="cart-items">
+            {items.map((item) => (
+              <li key={item.id} className="cart-item">
+                {item.image && <img src={item.image} alt="" className="cart-item-image" />}
+                <div className="cart-item-details">
+                  <h2>{item.name}</h2>
+                  <p>{formatCurrency(item.price)} each</p>
+                </div>
+                <label className="cart-quantity">
+                  <span>Qty</span>
+                  <input
+                    min="0"
+                    type="number"
+                    value={item.quantity}
+                    onChange={(event) => updateQuantity(item.id, event.target.value)}
+                  />
+                </label>
+                <p className="cart-line-total">{formatCurrency(item.price * item.quantity)}</p>
+                <button type="button" className="cart-remove-btn" onClick={() => removeItem(item.id)}>
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          <aside className="cart-summary" aria-label="Cart summary">
+            <p>
+              <span>Items</span>
+              <strong>{itemCount}</strong>
+            </p>
+            <p>
+              <span>Subtotal</span>
+              <strong>{formatCurrency(subtotal)}</strong>
+            </p>
+            <button type="button" className="checkout-start-btn" onClick={handleCheckoutStart}>
+              Start Checkout
+            </button>
+            <button type="button" className="cart-clear-btn" onClick={clearCart}>
+              Clear Cart
+            </button>
+          </aside>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/views/Shop.css
+++ b/src/views/Shop.css
@@ -108,3 +108,23 @@
   }
 }
 /* Responsive Design */
+
+.add-to-cart-btn {
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-family: 'Audiowide', 'Segoe UI', Arial, sans-serif;
+  font-size: 1rem;
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: linear-gradient(135deg, #7b61ff, #ffe97a);
+  color: lch(10% 10 265);
+  box-shadow: 0 4px 12px lch(45% 60 285 / 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.add-to-cart-btn:hover,
+.add-to-cart-btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 18px lch(45% 60 285 / 0.28);
+}

--- a/src/views/Shop.jsx
+++ b/src/views/Shop.jsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import AnalyticsContext from '../AnalyticsContext.jsx';
+import { useCart } from '../CartContext.jsx';
 import './Shop.css';
 
 /*
@@ -43,90 +44,105 @@ import './Shop.css';
 */
 const products = [
   {
+    id: 'a-plus-albinos',
     name: 'A+ Albinos',
     image: '/assets/A+%20ALBINOS.jpg',
     description: 'Rare white variant prized by collectors.',
     price: '$25',
   },
   {
+    id: 'blue-mini',
     name: 'Blue Mini',
     image: '/assets/BLUE%20MINI.jpg',
     description: 'Compact variety with vivid blue hues.',
     price: '$18',
   },
   {
+    id: 'hill-billy',
     name: 'Hill Billy',
     image: '/assets/HILL%20BILLY.jpg',
     description: 'Hardy strain known for vigorous growth.',
     price: '$19',
   },
   {
+    id: 'jedi-mind-f',
     name: 'Jedi Mind F',
     image: '/assets/JEDI%20MIND%20FUCKS.webp',
     description: 'Popular among experienced cultivators.',
     price: '$24',
   },
   {
+    id: 'mazatapec',
     name: 'Mazatapec',
     image: '/assets/MAZATAPEC.jpg',
     description: 'Classic Psilocybe cubensis strain from Mexico.',
     price: '$20',
   },
   {
+    id: 'natal-super-strength',
     name: 'Natal Super Strength',
     image: '/assets/NATAL%20SUPER%20STRENGTH.jpg',
     description: 'Robust spores ideal for advanced growers.',
     price: '$26',
   },
   {
+    id: 'pe6',
     name: 'P.E.6',
     image: '/assets/P%20E6.png',
     description: 'Penis Envy hybrid with unique genetics.',
     price: '$23',
   },
   {
+    id: 'penis-envy',
     name: 'Penis Envy',
     image: '/assets/PENIS%20ENVY.png',
     description: 'Legendary potency and strong colonization.',
     price: '$28',
   },
   {
+    id: 'pf-classic',
     name: 'PF Classic',
     image: '/assets/PF%20CLASSIC.jpg',
     description: 'Beginner-friendly spores for PF Tek enthusiasts.',
     price: '$15',
   },
   {
+    id: 'treasure-coast',
     name: 'Treasure Coast',
     image: '/assets/TREASURE%20COAST.webp',
     description: 'Florida strain famous for large flushes.',
     price: '$21',
   },
   {
+    id: 'burma',
     name: 'Burma',
     image: '/assets/burma%20mushrooms.jpg',
     description: 'Exotic variety from Southeast Asia.',
     price: '$20',
   },
   {
+    id: 'z-strain',
     name: 'Z-Strain',
     image: '/assets/z%20strain.jpg',
     description: 'Popular strain known for consistent growth.',
     price: '$22',
   },
   {
+    id: 'pe6-webp',
     name: 'P.E.6 Webp',
     image: '/assets/P%20E6.webp',
     description: 'Alternate image format of P.E.6 spores.',
     price: '$23',
   },
   {
+    id: 'shrooms-1',
     name: 'Shrooms 1',
     image: '/assets/Shrooms_1.PNG',
     description: 'Colorful promotional artwork.',
     price: '$18',
   },
   {
+    id: 'shrooms-2',
     name: 'Shrooms 2',
     image: '/assets/Shrooms_2.PNG',
     description: 'More spores with an artistic twist.',
@@ -136,6 +152,7 @@ const products = [
 
 export default function Shop() {
   const { recordPageView, recordProductView } = useContext(AnalyticsContext);
+  const { addItem } = useCart();
 
   useEffect(() => {
     recordPageView('Shop');
@@ -154,6 +171,16 @@ export default function Shop() {
             <h2>{p.name}</h2>
             <p className="description">{p.description}</p>
             <p className="price">{p.price}</p>
+            <button
+              type="button"
+              className="add-to-cart-btn"
+              onClick={(event) => {
+                event.stopPropagation();
+                addItem(p);
+              }}
+            >
+              Add to Cart
+            </button>
           </div>
         ))}
       </section>


### PR DESCRIPTION
### Motivation

- Provide a simple, app-wide cart state layer with core actions and durable persistence so users can add/remove items and continue later. 
- Surface cart UI and navigation so users can review quantities, subtotal, and start checkout. 
- Ensure commerce interactions are tracked through the existing analytics pipeline with a reusable `recordEvent` API. 

### Description

- Added `src/CartContext.jsx` which implements `CartProvider`, `useCart()`, localStorage persistence under the `cart:v1` key, and core actions `addItem(product)`, `removeItem(productId)`, `updateQuantity(productId, quantity)`, and `clearCart()`; actions emit analytics events via `recordEvent`.
- Extended `src/AnalyticsContext.jsx` with a `recordEvent` API and adapted providers to expose `recordEvent`, `recordPageView`, and `recordProductView` via memoized values.
- Wrapped the app with `CartProvider` in `src/main.jsx` so cart state is available across routes.
- Added product `id` fields and an “Add to Cart” button to each product card in `src/views/Shop.jsx`; the button calls `event.stopPropagation()` and `addItem(p)` and uses new `add-to-cart-btn` styling in `src/views/Shop.css`.
- Added a cart page `src/views/Cart.jsx` and styles `src/views/Cart.css` showing line items, editable quantities, per-line totals, subtotal, item count, `Start Checkout` (emits `checkout_start`) and `Clear Cart` actions.
- Registered the `/cart` route in `src/App.jsx` and added cart navigation links (with icons) to `src/components/SideBar.jsx` and `src/components/Footer.jsx`.
- Hardened cart helpers: product normalization, safe price parsing, quantity normalization, and safer event metadata for `cart_add`, `cart_remove`, `quantity_change`, and `checkout_start`.

### Testing

- Ran the production build with `npm run build`, which completed successfully and produced `dist/` assets.
- Started the dev server (`vite --host`) during verification and it launched successfully (dev server ready).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bbd4f7bf88329898755a940fb43ca)